### PR TITLE
Restructuring http-downloader.yml to construct right path for a windows machine

### DIFF
--- a/config/linuxsuren/http-downloader.yml
+++ b/config/linuxsuren/http-downloader.yml
@@ -3,3 +3,4 @@ binary: hd
 formatOverrides:
   windows: zip
   linux: tar.gz
+

--- a/config/linuxsuren/http-downloader.yml
+++ b/config/linuxsuren/http-downloader.yml
@@ -1,2 +1,5 @@
-filename: "hd-{{.OS}}-{{.Arch}}.tar.gz"
+filename: "hd-{{.OS}}-{{.Arch}}"
 binary: hd
+formatOverrides:
+  windows: zip
+  linux: tar.gz


### PR DESCRIPTION
This PR handles support to construct the right path or the source package based on the type of OS the host is using.
fixes https://github.com/LinuxSuRen/http-downloader/issues/137