### PR TITLE
fixbug: velero install error in windows

### DIFF
--- a/config/vmware-tanzu/velero.yml
+++ b/config/vmware-tanzu/velero.yml
@@ -1,5 +1,1 @@
-filename: "{{.Name}}-{{.Version}}-{{.OS}}-{{.Arch}}"
-tar: true          # if this is a tar file
-formatOverrides:   # set the file extension for different platforms
-  windows: zip
-  linux: tar.gz
+filename: "{{.Name}}-{{.Version}}-{{.OS}}-{{.Arch}}.tar.gz"


### PR DESCRIPTION
error screenshot:

![image](https://user-images.githubusercontent.com/232069/167578959-399764e0-a52b-4901-8564-bef70308846d.png)

Because all platform package formats have become tar.gz
![image](https://user-images.githubusercontent.com/232069/167579123-bd232d90-954b-41eb-b345-7c56bb57acb8.png)
